### PR TITLE
CSharp Support Release/3.12.0 rc2

### DIFF
--- a/templates/csharp/shopping-cart/CloudState.CSharpTemplate.csproj
+++ b/templates/csharp/shopping-cart/CloudState.CSharpTemplate.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="CloudState.CSharpSupport" Version="3.12.0-rc2" />
+    <PackageReference Include="Grpc.Tools" Version="2.25" />
   </ItemGroup>
 
 </Project>

--- a/templates/csharp/shopping-cart/CloudState.CSharpTemplate.csproj
+++ b/templates/csharp/shopping-cart/CloudState.CSharpTemplate.csproj
@@ -3,25 +3,16 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="proto_files/frontend/**/*.proto;proto_files/example/**/*.proto" ProtoRoot="proto_files/frontend;proto_files/example" OutputDir="proto_dist" CompileOutputs="false" GrpcServices="None" />
+    <Protobuf Include="proto_files/frontend/**/*.proto;proto_files/example/**/*.proto" ProtoRoot="proto_files/frontend;proto_files" GrpcServices="None" />
     <Protobuf Update="proto_files/example/shoppingcart/shoppingcart.proto" GrpcServices="Both" />
   </ItemGroup>
 
   <ItemGroup>
-    <!-- TODO: fix the .461 build warnings -->    
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Custom built library with a patched version of protobuf -->
-    <PackageReference Include="cloudstate.csharpsupport" Version="3.11.0-rc0.12" />
-    <!-- TODO: Add these to the nuget package -->
-    <PackageReference Include="Grpc.Core" Version="2.23.1" />
-    <PackageReference Include="Grpc.Tools" Version="2.23.1" />
-    <PackageReference Include="Optional" Version="4.0.0" />
-    <PackageReference Include="Grpc.Reflection" Version="2.0.0.0" />
+    <PackageReference Include="CloudState.CSharpSupport" Version="3.12.0-rc2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
As noted in the csharp-support repo, this will update your template to the latest version.  It should also get rid of the user-function pod error.